### PR TITLE
Feature/refactor config

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Plugins push the result data into the OutputSink.
         "name": "TukeysFilter"
       }
     },
-    "worker_options": {
+    "service_options": {
       "service1": {}
     }
   }
@@ -256,7 +256,7 @@ Each key in the `services.json` file defines an algorithm that will run (here `T
     - **interval_secs** - how often the tasks should run
     - **plugin_args** - arguments for the Poll Task
       - name - Mandatory plugin name.
-- **worker_options** - options for the each Task Runner
+- **service_options** - options for the each Task Runner
 
 ## Algorithms
 

--- a/config/collector.example.json
+++ b/config/collector.example.json
@@ -3,24 +3,7 @@
     "blacklist": [
       "MX",
       "osys.*"
-    ],
-    "whitelist": {
-      ".*": [
-        {
-          "RedisTimeStamped": {
-            "ttl": 10000
-          }
-        }
-      ],
-      ".cpu*": [
-        {
-          "RedisIntervalTimeStamped": {
-            "ttl": 1000,
-            "interval": 300
-          }
-        }
-      ]
-    }
+    ]
   },
   "writer": {
     "RedisSink": {

--- a/config/services.example.json
+++ b/config/services.example.json
@@ -6,15 +6,22 @@
         "name": "TukeysFilter"
       }
     },
-    "worker_options": {
+    "service_options": {
       "service1": {
         "quantile_25": "service.quartil_25",
         "quantile_75": "service.quartil_75",
         "iqr_scaling": 2,
-        "metrics": "system.*",
+        "metric": "system.*",
         "default": 0,
         "offset": 60,
-        "maximum_delay": 900
+        "maximum_delay": 900,
+        "model": [
+          {
+            "RedisTimeStamped": {
+              "ttl": 10000
+            }
+          }
+        ]
       }
     }
   },
@@ -25,7 +32,7 @@
         "name": "SeasonalDecomposition"
       }
     },
-    "worker_options": {
+    "service_options": {
       "stl_service1": {
         "metric": "system.loadavg",
         "period_length": 6,
@@ -36,7 +43,15 @@
           "alpha": 0.01,
           "minimal_upper_threshold": 0.1,
           "minimal_lower_threshold": -0.1
-        }
+       },
+       "model": [
+          {
+            "RedisIntervalTimeStamped": {
+              "ttl": 10000,
+              "interval": 300
+            }
+          }
+       ]
       }
     }
   },
@@ -47,9 +62,9 @@
         "name": "SeasonalDecompositionEnsemble"
       }
     },
-    "worker_options": {
+    "service_options": {
       "stle_service1": {
-        "metric": "system.loadavg",
+        "metric": "system.loadavg_*",
         "period_length": 6,
         "seasons": 2,
         "interval": 10,
@@ -58,7 +73,15 @@
           "minimal_upper_threshold": 0.1,
           "minimal_lower_threshold": -0.1,
           "treshold": 2
-        }
+        },
+       "model": [
+          {
+            "RedisIntervalTimeStamped": {
+              "ttl": 10000,
+              "interval": 300
+            }
+          }
+       ]
       }
     }
   },
@@ -69,7 +92,7 @@
         "name": "FlowDifference"
       }
     },
-    "worker_options": {
+    "service_options": {
       "fd_service1": {
         "in_metric": "service1.out",
         "out_metric": "service2.in",
@@ -78,7 +101,15 @@
           "scaling": 2,
           "minimal_upper_threshold": 0.1,
           "minimal_lower_threshold": -0.1
-        }
+        },
+       "model": [
+          {
+            "RedisIntervalTimeStamped": {
+              "ttl": 10000,
+              "interval": 300
+            }
+          }
+       ]
       }
     }
   }

--- a/lib/plugins/poll_task.py
+++ b/lib/plugins/poll_task.py
@@ -18,7 +18,7 @@ class PollTask(BaseTask):
     def run(self):
         try:
             algo_config = config_loader.load(os.path.join(os.path.dirname(__file__), '../../config/services.json'))
-            algo_config = algo_config.get(self.plugin_name)['worker_options']
+            algo_config = algo_config.get(self.plugin_name)['service_options']
         except AttributeError:
             return None
         for service, options in algo_config.iteritems():

--- a/lib/plugins/tukeys_filter.py
+++ b/lib/plugins/tukeys_filter.py
@@ -22,7 +22,7 @@ class TukeysFilter(BaseTask):
     def read(self):
         quantile_25 = self.params['quantile_25']
         quantile_75 = self.params['quantile_75']
-        metrics = self.params['metrics']
+        metrics = self.params['metric']
         delay = self.params.get('offset', 0)
         maximum_delay = self.params.get('maximum_delay', 600)
 

--- a/test/fixtures/config.py
+++ b/test/fixtures/config.py
@@ -50,11 +50,17 @@ services = {
                 'name': 'TukeysFilter'
             }
         },
-        'worker_options': {
+        'service_options': {
             'service1': {
-                'options': {
-                    'quantile_25': 'service.quartil_25'
-                }
+                'metric': 'cpu',
+                'quantile_25': 'service.quartil_25',
+                "model": [
+                    {
+                        "RedisTimeStamped": {
+                            "ttl": 10000
+                        }
+                    }
+                ]
             }
         }
     },
@@ -65,13 +71,21 @@ services = {
                 'name': 'SeasonalDecomposition'
             }
         },
-        'worker_options': {
+        'service_options': {
             'stl_service1': {
                 'metric': 'cpu',
                 'period_length': 3,
                 'seasons': 2,
                 'interval': 1,
-                'error_params': {}
+                'error_params': {},
+                "model": [
+                    {
+                        "RedisIntervalTimeStamped": {
+                            "ttl": 10000,
+                            "interval": 300
+                        }
+                    }
+                ]
             }
         }
     },
@@ -82,13 +96,21 @@ services = {
                 'name': 'SeasonalDecompositionEnsemble'
             }
         },
-        'worker_options': {
+        'service_options': {
             'stle_service1': {
                 'metric': 'cpu',
                 'period_length': 3,
                 'seasons': 2,
                 'interval': 1,
-                'error_params': {}
+                'error_params': {},
+                "model": [
+                    {
+                        "RedisIntervalTimeStamped": {
+                            "ttl": 10000,
+                            "interval": 300
+                        }
+                    }
+                ]
             }
         }
     },
@@ -99,24 +121,27 @@ services = {
                 'name': 'FlowDifference'
             }
         },
-        'worker_options': {
+        'service_options': {
             'flow_service1': {
                 'in_metric': 'service1.out',
                 'out_metric': 'service2.in',
                 'stale': 10,
-                'error_params': {}
+                'error_params': {},
+                "model": [
+                    {
+                        "RedisIntervalTimeStamped": {
+                            "ttl": 10000,
+                            "interval": 300
+                        }
+                    }
+                ]
             }
         }
-    },
+    }
 }
 
 collector = {
     'router': {
-        'blacklist': ['.*_crit.*'],
-        'whitelist': {
-            'host.ip.*serv1.*cpu.*': [{
-                'RedisTimeStamped': {'ttl': 10}
-            }]
-        }
+        'blacklist': ['.*_crit.*']
     }
 }

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -14,7 +14,7 @@ class TestCollector(object):
 
     @classmethod
     def setUpAll(cls):
-        options = Mock(**{'config': './collector.json'})
+        options = Mock(**{'collector_config': './collector.json', 'services_config': './services.json'})
         collector.setup(options)
 
     def setUp(self):
@@ -23,7 +23,7 @@ class TestCollector(object):
     # process
 
     def test_collector_process_accepts_whitelisted_and_not_blacklisted_metrics(self):
-        collector.process(self.writer, TimeSeriesTuple('host.ip.127-0-0-1.serv1.cpu.avg', 1, 1))
+        collector.process(self.writer, TimeSeriesTuple('cpu', 1, 1))
         self.writer.write.called.should.be.true
 
     def test_collector_process_ignores_not_whitelisted_metrics(self):
@@ -33,3 +33,9 @@ class TestCollector(object):
     def test_collector_process_ignores_whitelisted_but_blacklisted_metrics(self):
         collector.process(self.writer, TimeSeriesTuple('host.ip.127-0-0-1.serv1.cpu_crit.avg', 1, 1))
         self.writer.write.called.should.be.false
+
+    def test_collector_process_accepts_whitelisted_and_not_blacklisted_FlowDifference_metrics(self):
+        collector.process(self.writer, TimeSeriesTuple('service1.out', 1, 1))
+        self.writer.write.called.should.be.true
+        collector.process(self.writer, TimeSeriesTuple('service2.in', 1, 1))
+        self.writer.write.called.should.be.true

--- a/test/test_flow_difference.py
+++ b/test/test_flow_difference.py
@@ -14,7 +14,7 @@ from fixtures.config import services, analyzer
 
 class TestFlowDifference(object):
     def __init__(self):
-        self.config = services['FlowDifference']['worker_options']
+        self.config = services['FlowDifference']['service_options']
 
     def setUp(self):
         base_task.sink = Mock()

--- a/test/test_poll_task.py
+++ b/test/test_poll_task.py
@@ -39,7 +39,7 @@ class TestPollTask(object):
                 self.test_poll_task = poll_task.PollTask(config=analyzer, logger=None, options={'name': plugin_name})
                 self.test_poll_task.should.have.property('plugin_name').being.equal(plugin_name)
                 self.test_poll_task.should.have.property('plugin').being.equal(plugin)
-                config = services[plugin_name]['worker_options']
+                config = services[plugin_name]['service_options']
                 params = {
                     'service': config.keys()[0],
                     'params': config.values()[0]

--- a/test/test_seasonal_decomposition.py
+++ b/test/test_seasonal_decomposition.py
@@ -16,7 +16,7 @@ from fixtures.config import services, analyzer
 
 class TestSeasonalDecomposition(object):
     def __init__(self):
-        self.config = services['SeasonalDecomposition']['worker_options']
+        self.config = services['SeasonalDecomposition']['service_options']
 
     def setUp(self):
         base_task.sink = Mock()

--- a/test/test_seasonal_decomposition_ensemble.py
+++ b/test/test_seasonal_decomposition_ensemble.py
@@ -15,7 +15,7 @@ from fixtures.config import services, analyzer
 
 class TestSeasonalDecompositionEnsemble(object):
     def __init__(self):
-        self.config = services['SeasonalDecompositionEnsemble']['worker_options']
+        self.config = services['SeasonalDecompositionEnsemble']['service_options']
 
     def setUp(self):
         base_task.sink = Mock()


### PR DESCRIPTION
This PR refactors the config files `services.json` and `collector.json` and redefines the meaning of `whitelist`.

**WHITELIST** : All the metrics that are processed by workers are by de-facto in `whitelist` This approach has multiple advantages:
    \* It prevents the unnecessary collection of metrics by the collector (but not used by workers) and bloating the redis sink.
    \* Removes the need to ensure that the metrics the `workers` use are also collected by the `collector`
