### PR TITLE
fix InsecurePlatformWarning with urllib3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,11 @@ echo Installing depedencies...
 sudo apt-get update
 sudo apt-get install -y build-essential python-pip redis-server automake r-base python-dev libtool
 sudo pip install -U pip
+
+#InsecurePlatformWarning
+sudo pip install --upgrade requests[security]
+
+#install project dependencies
 sudo pip install -r /opt/anna-molly/requirements.txt
 
 SCRIPT


### PR DESCRIPTION
This PR fixes the [InsecurePlatformWarning](http://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning) Error when booting the provided vagrant file.

This should eventually be gone once Python version 2.7.9 package is available for ubuntu.
